### PR TITLE
[SeparateHearts] 屏蔽文件名错误

### DIFF
--- a/015.SeparateHearts/SeparateHeartsEngineExtractor/EngineCoreStatic/HACImageDecoder.cs
+++ b/015.SeparateHearts/SeparateHeartsEngineExtractor/EngineCoreStatic/HACImageDecoder.cs
@@ -692,8 +692,8 @@ namespace EngineCoreStatic
                     {
                         //输出散装图片
                         {
-                            string layerPath = Path.Combine(baseDir, layer.Name + ".png");
-
+                            string layerPath = Path.Combine(baseDir, HACStreamExtend.CleanFileName(layer.Name) + ".png");
+                            
                             {
                                 if(Path.GetDirectoryName(layerPath) is string dir && !Directory.Exists(dir))
                                 {

--- a/015.SeparateHearts/SeparateHeartsEngineExtractor/EngineCoreStatic/HACStreamExtend.cs
+++ b/015.SeparateHearts/SeparateHeartsEngineExtractor/EngineCoreStatic/HACStreamExtend.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.Text;
 using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace EngineCoreStatic
 {
@@ -54,6 +56,32 @@ namespace EngineCoreStatic
             }
 
             return data;
+        }
+
+        public static string CleanFileName(string name)
+        {
+            // Windows file names cannot contain the following characters
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+
+            // Remove invalid characters
+            string cleanedName = new string(name
+                .Where(c => !invalidChars.Contains(c))
+                .ToArray());
+
+            // Also remove control characters (e.g., newlines, carriage returns)
+            cleanedName = Regex.Replace(cleanedName, @"[\x00-\x1F]", "");
+
+            // If the cleaned name is empty, return random hex number
+            if (string.IsNullOrEmpty(cleanedName))
+            {
+                var rand = new Random();
+                var randnum = rand.Next(0x10000);
+                return Convert.ToString(randnum, 16);
+            }
+            else
+            {
+                return cleanedName;
+            }
         }
     }
 }


### PR DESCRIPTION
尝试用此工具解包《夏梦夜话》中文版时，对于特定的一个HGP文件报错，其中原因可能是解析出的文件名包含不合法的字符（\*）。个人能力有限，没有继续深入查明原因，只是加了个字符串异常处理，目前不报错了，能正确解析内容。
<img width="734" alt="无标题" src="https://github.com/user-attachments/assets/a7f96567-1412-4c86-b57f-d240c18b1087">

异常HGP文件
[temp.zip](https://github.com/user-attachments/files/16839441/temp.zip)
